### PR TITLE
Small refactoring: init vars as consts

### DIFF
--- a/module/index.js
+++ b/module/index.js
@@ -1,16 +1,16 @@
 import arityN from 'arity-n';
 
 
-let compose2 = (f, g) => (...args) => f(g(...args));
+const compose2 = (f, g) => (...args) => f(g(...args));
 
 export default function compose(...functions) {
 
   const funcs = functions.filter(fn => typeof fn === 'function');
 
-  let lastIdx = funcs.length - 1;
+  const lastIdx = funcs.length - 1;
   let arity = 0;
 
-  if (funcs.length <= 0) {
+  if (lastIdx < 0) {
     throw new Error('No funcs passed');
   }
 


### PR DESCRIPTION
Not sure if you want to follow such style, but it looks like `compose2` and `lastIdx` should not be reassigned.
